### PR TITLE
Autoselect current folder when adding a new feed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
       with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./yarr-windows.zip
-          asset_name: yarr-${{ github.ref }}-windows32.zip
+          asset_name: yarr-${{ github.ref }}-windows64.zip
           asset_content_type: application/zip
     - name: Upload Linux
       uses: actions/upload-release-asset@v1
@@ -140,5 +140,5 @@ jobs:
       with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./yarr-linux.zip
-          asset_name: yarr-${{ github.ref }}-linux32.zip
+          asset_name: yarr-${{ github.ref }}-linux64.zip
           asset_content_type: application/zip

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -6,6 +6,7 @@
 - (fix) pagination in unread/starred feeds (thanks to @Farow for the report)
 - (fix) handling feeds with non-utf8 encodings (thanks to @fserb for the report)
 - (fix) errors caused by empty feeds (thanks to @decke)
+- (fix) recognize all audio mime types as podcasts (thanks to @krkk)
 - (fix) ui tweaks (thanks to @Farow)
 
 # v2.0 (2021-04-18)

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -1,4 +1,4 @@
-# upcoming
+# v2.1 (2021-08-16)
 
 - (new) configuration via env variables
 - (fix) missing `content-type` headers (thanks to @verahawk for the report)

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-VERSION=2.0
+VERSION=2.1
 GITHASH=$(shell git rev-parse --short=8 HEAD)
 
 CGO_ENABLED=1

--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -350,7 +350,7 @@
                     </label>
                     <select class="form-control" id="feed-folder" name="folder_id" ref="newFeedFolder">
                         <option value="">---</option>
-                        <option :value="folder.id" v-for="folder in folders">{{ folder.title }}</option>
+                        <option :value="folder.id" v-for="folder in folders" :selected="folder.id === current.feed.folder_id || folder.id === current.folder.id">{{ folder.title }}</option>
                     </select>
                     <div class="mt-4" v-if="feedNewChoice.length">
                         <p class="mb-2">

--- a/src/parser/rss.go
+++ b/src/parser/rss.go
@@ -71,7 +71,7 @@ func ParseRSS(r io.Reader) (*Feed, error) {
 	for _, srcitem := range srcfeed.Items {
 		podcastURL := ""
 		for _, e := range srcitem.Enclosures {
-			if e.Type == "audio/mpeg" || e.Type == "audio/x-m4a" {
+			if strings.HasPrefix(e.Type, "audio/") {
 				podcastURL = e.URL
 
 				if srcitem.OrigEnclosureLink != "" && strings.Contains(podcastURL, path.Base(srcitem.OrigEnclosureLink)) {

--- a/src/parser/rss_test.go
+++ b/src/parser/rss_test.go
@@ -136,6 +136,26 @@ func TestRSSPodcast(t *testing.T) {
 	}
 }
 
+func TestRSSOpusPodcast(t *testing.T) {
+	feed, _ := Parse(strings.NewReader(`
+		<?xml version="1.0" encoding="UTF-8"?>
+		<rss version="2.0">
+			<channel>
+				<item>
+					<enclosure length="100500" type="audio/opus" url="http://example.com/audio.ext"/>
+				</item>
+			</channel>
+		</rss>
+	`))
+	have := feed.Items[0].AudioURL
+	want := "http://example.com/audio.ext"
+	if want != have {
+		t.Logf("want: %#v", want)
+		t.Logf("have: %#v", have)
+		t.FailNow()
+	}
+}
+
 // found in: https://podcast.cscript.site/podcast.xml
 func TestRSSPodcastDuplicated(t *testing.T) {
 	feed, _ := Parse(strings.NewReader(`


### PR DESCRIPTION
This patch that has been laying around for some time until someone on the potential features issue reminded me that I haven't actually opened PR for it.

i'll just put this here so people only have one place with features. :)

---
This patch makes categorising new feeds a bit more intuitive: the selected folder (or feed within a folder) in the feed list will also be selected when adding a new feed.